### PR TITLE
Add an option for the default view to show on startup. Fixes #57

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -280,4 +280,6 @@
   <string name="preferences_days_per_week_dialog">"Anzahl Tage pro Woche"</string>
   <string name="preferences_days_per_week_title">"Anzahl Tage pro Woche"</string>
   <string name="goto_date">"Gehe zu..."</string>
+  <string name="default_start_last">Letzte aktive Ansicht</string>
+  <string name="default_start_title">Standardansicht</string>
 </resources>

--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -27,4 +27,22 @@
         <item>"180"</item>
         <item>"720"</item>
     </string-array>
+
+    <!-- Labels for the default startup page preference. -->
+    <string-array name="default_start_entries" translatable="false">
+        <item>@string/default_start_last</item>
+        <item>@string/day_view</item>
+        <item>@string/week_view</item>
+        <item>@string/month_view</item>
+        <item>@string/agenda_view</item>
+    </string-array>
+
+    <!-- Values for the default startup page preference. See CalendarController.ViewType.  -->
+    <string-array name="default_start_values" translatable="false">
+        <item>-2</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>1</item>
+    </string-array>
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -27,4 +27,8 @@
     <string name="preferences_default_snooze_delay_dialog">Default snooze delay</string>
     <!-- Default value for the default snooze delay (in minutes) -->
     <string name="preferences_default_snooze_delay_default" translatable="false">5</string>
+
+    <!-- Label values for the default start page preference. -->
+    <string name="default_start_title">Default view</string>
+    <string name="default_start_last">Previously used view</string>
 </resources>

--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -22,6 +22,12 @@
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_values"
             android:defaultValue="light"/>
+        <ListPreference
+            android:key="preferences_default_start"
+            android:defaultValue="-2"
+            android:title="@string/default_start_title"
+            android:entries="@array/default_start_entries"
+            android:entryValues="@array/default_start_values" />
         <CheckBoxPreference
             android:key="preferences_hide_declined"
             android:defaultValue="false"

--- a/src/com/android/calendar/GeneralPreferences.java
+++ b/src/com/android/calendar/GeneralPreferences.java
@@ -59,6 +59,7 @@ public class GeneralPreferences extends PreferenceFragment implements
         OnSharedPreferenceChangeListener, OnPreferenceChangeListener, OnTimeZoneSetListener {
     // Preference keys
     public static final String KEY_THEME_PREF = "pref_theme";
+    public static final String KEY_DEFAULT_START = "preferences_default_start";
     public static final String KEY_HIDE_DECLINED = "preferences_hide_declined";
     public static final String KEY_WEEK_START_DAY = "preferences_week_start_day";
     public static final String KEY_SHOW_WEEK_NUM = "preferences_show_week_num";
@@ -95,6 +96,7 @@ public class GeneralPreferences extends PreferenceFragment implements
     public static final String WEEK_START_SUNDAY = "1";
     public static final String WEEK_START_MONDAY = "2";
     // Default preference values
+    public static final String DEFAULT_DEFAULT_START = "-2";
     public static final int DEFAULT_START_VIEW = CalendarController.ViewType.WEEK;
     public static final int DEFAULT_DETAILED_VIEW = CalendarController.ViewType.DAY;
     public static final boolean DEFAULT_SHOW_WEEK_NUM = false;
@@ -125,6 +127,7 @@ public class GeneralPreferences extends PreferenceFragment implements
     ListPreference mDayWeek;
     ListPreference mDefaultReminder;
     ListPreference mSnoozeDelay;
+    ListPreference mDefaultStart;
 
     private String mTimeZoneId;
 
@@ -178,6 +181,7 @@ public class GeneralPreferences extends PreferenceFragment implements
         mPopup = (CheckBoxPreference) preferenceScreen.findPreference(KEY_ALERTS_POPUP);
         mUseHomeTZ = (CheckBoxPreference) preferenceScreen.findPreference(KEY_HOME_TZ_ENABLED);
         mTheme = (ListPreference) preferenceScreen.findPreference(KEY_THEME_PREF);
+        mDefaultStart = (ListPreference) preferenceScreen.findPreference(KEY_DEFAULT_START);
         mHideDeclined = (CheckBoxPreference) preferenceScreen.findPreference(KEY_HIDE_DECLINED);
         mWeekStart = (ListPreference) preferenceScreen.findPreference(KEY_WEEK_START_DAY);
         mDayWeek = (ListPreference) preferenceScreen.findPreference(KEY_DAYS_PER_WEEK);
@@ -191,6 +195,7 @@ public class GeneralPreferences extends PreferenceFragment implements
         mDayWeek.setSummary(mDayWeek.getEntry());
         mDefaultReminder.setSummary(mDefaultReminder.getEntry());
         mSnoozeDelay.setSummary(mSnoozeDelay.getEntry());
+        mDefaultStart.setSummary(mDefaultStart.getEntry());
 
         // This triggers an asynchronous call to the provider to refresh the data in shared pref
         mTimeZoneId = Utils.getTimeZone(activity, null);
@@ -269,6 +274,7 @@ public class GeneralPreferences extends PreferenceFragment implements
         mUseHomeTZ.setOnPreferenceChangeListener(listener);
         mHomeTZ.setOnPreferenceChangeListener(listener);
         mTheme.setOnPreferenceChangeListener(listener);
+        mDefaultStart.setOnPreferenceChangeListener(listener);
         mWeekStart.setOnPreferenceChangeListener(listener);
         mDayWeek.setOnPreferenceChangeListener(listener);
         mDefaultReminder.setOnPreferenceChangeListener(listener);
@@ -352,6 +358,10 @@ public class GeneralPreferences extends PreferenceFragment implements
             return true;
         } else if (preference == mVibrate) {
             mVibrate.setChecked((Boolean) newValue);
+            return true;
+        } else if (preference == mDefaultStart) {
+            int i = mDefaultStart.findIndexOfValue((String) newValue);
+            mDefaultStart.setSummary(mDefaultStart.getEntries()[i]);
             return true;
         } else {
             return true;

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -215,9 +215,17 @@ public class Utils {
             }
         }
 
-        // Default to the last view
-        return prefs.getInt(
-                GeneralPreferences.KEY_START_VIEW, GeneralPreferences.DEFAULT_START_VIEW);
+        // Check if the user wants the last view or the default startup view
+        int defaultStart = Integer.valueOf(prefs.getString(GeneralPreferences.KEY_DEFAULT_START,
+                GeneralPreferences.DEFAULT_DEFAULT_START));
+        if (defaultStart == -2) {
+            // Return the last view used
+            return prefs.getInt(
+                    GeneralPreferences.KEY_START_VIEW, GeneralPreferences.DEFAULT_START_VIEW);
+        } else {
+            // Return the default view
+            return defaultStart;
+        }
     }
 
     /**


### PR DESCRIPTION
Typically, the Calendar application opens with the previously used view
(day, week, ...). This adds an option to select another view as the
default when starting the app.