### PR TITLE
Calendar does not use cleartext network traffic.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -47,6 +47,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/standalone_app_label"
         android:taskAffinity="ws.xsoh.etar.task"
+        android:requiredAccountType="*"
+        android:usesCleartextTraffic="false"
         android:theme="@style/CalendarAppTheme">
 
         <activity


### PR DESCRIPTION
This declares to the platform and tools that this app does not use
cleartext network traffic. The platform and tools will be blocking (on
best effort basis) attempts to use such traffic by this app. For
example, attempts to use HTTP (rather than HTTPS) will be blocked.

Bug: 19215516
Change-Id: Ib51bc0deeb2135f614f2170efd2a7c9dcd67316f