### PR TITLE
Fix sound setting on Android 6 by not de-registering settings listeners

### DIFF
--- a/src/com/android/calendar/GeneralPreferences.java
+++ b/src/com/android/calendar/GeneralPreferences.java
@@ -288,7 +288,6 @@ public class GeneralPreferences extends PreferenceFragment implements
     public void onStop() {
         getPreferenceScreen().getSharedPreferences()
                 .unregisterOnSharedPreferenceChangeListener(this);
-        setPreferenceListeners(null);
         super.onStop();
     }
 


### PR DESCRIPTION
Because choosing a sound is a separate activity on Android 6, the
onPause and onStop methods are called so the app doesn't observe
the settings values changing.

There doesn't seem to be a good reason to de-register from settings
listeners. I couldn't find any API notes or reference code that
indicated this should ever be done.